### PR TITLE
Prevent System.ArgumentOutOfRangeException when %GSNET std output mes…

### DIFF
--- a/Ghostscript.NET/Viewer/FormatHandlers/GhostscriptViewerPdfFormatHandler.cs
+++ b/Ghostscript.NET/Viewer/FormatHandlers/GhostscriptViewerPdfFormatHandler.cs
@@ -127,7 +127,7 @@ namespace Ghostscript.NET.Viewer
                 int startPos = message.IndexOf(PDF_TAG);
                 int endPos = message.IndexOf(": ");
 
-                string tag = message.Substring(startPos, endPos + 2);
+                string tag = message.Substring(startPos, endPos - startPos + 2);
                 string rest = message.Substring(endPos + 2, message.Length - endPos - 2);
 
                 switch (tag)


### PR DESCRIPTION
…sage does not occur at beginning of line.

Hi Josip, 
I was testing different ways of calling the gs api for a PDF and encountered something to contribute. On the standard out, I received this:
`  1  1  --nostringval--  --nostringval--  --nostringval--  4  --nostringval--  --nostringval--  Kids  known  typecheck  %GSNET_VIEWER_PDF_PAGE: 1`
I updated the format handler in this commit to correctly parse the tag when the %GSNET token is not the first thing in the line.
Thanks for writing this great tool,
Scott