### PR TITLE
Fix offset error in StdIn buffering

### DIFF
--- a/Ghostscript.NET/GhostscriptStdIO.cs
+++ b/Ghostscript.NET/GhostscriptStdIO.cs
@@ -144,7 +144,7 @@ namespace Ghostscript.NET
             }
 
             // remove written data out from the cached input
-            _input = _input.Remove(0, count);
+            _input = _input.Remove(0, position);
 
             // return number of bytes written
             return position;


### PR DESCRIPTION
When the stdin handler returns a string with a newline character,
the `GhostscriptStdIO` class incorrectly removes the number of
bytes requested from ghostscript rather than the number of bytes
processed before the early return.

Instead of removing `count` characters from the buffer string, remove
only `position` characters.