### PR TITLE
Fix Arithmetic overflow error at DynamicNativeLibrary.FinalizeSections when running on x86

### DIFF
--- a/Ghostscript.NET/Microsoft.WinAny.Helper/Interop/DynamicNativeLibrary.cs
+++ b/Ghostscript.NET/Microsoft.WinAny.Helper/Interop/DynamicNativeLibrary.cs
@@ -531,7 +531,7 @@ namespace Microsoft.WinAny.Interop
                 if ((section->Characteristics & WinNT.IMAGE_SCN_MEM_DISCARDABLE) != 0)
                 {
                     // section is not needed any more and can safely be freed
-                    WinBase.VirtualFree((IntPtr)((long)section->PhysicalAddress | (long)image_offset), section->SizeOfRawData, WinNT.MEM_DECOMMIT);
+                    WinBase.VirtualFree((IntPtr)(void*)((long)section->PhysicalAddress | (long)image_offset), section->SizeOfRawData, WinNT.MEM_DECOMMIT);
                     continue;
                 }
 
@@ -555,7 +555,7 @@ namespace Microsoft.WinAny.Interop
                 if (rawDataSize > 0)
                 {
                     // change memory access flags
-                    WinBase.VirtualProtect((IntPtr)((long)section->PhysicalAddress | (long)image_offset), rawDataSize, protect, &oldProtect);
+                    WinBase.VirtualProtect((IntPtr)(void*)((long)section->PhysicalAddress | (long)image_offset), rawDataSize, protect, &oldProtect);
                 }
             }
         }


### PR DESCRIPTION
# Background
When running on x86, new IntPtr(long value) attempts to convert the given value to a void* via `m_value = (void *)checked((int)value);` (see https://github.com/Microsoft/referencesource/blob/master/mscorlib/system/intptr.cs) .  This can cause an arithmetic overflow if the value passed is greater than int.MaxValue. 

# Problem
Depending on process memory usage, `section->PhysicalAddress` may result in a memory address greater than `int.MaxValue` if `gcAllowVeryLargeObjects` is set on the application environment.  This can cause an Arithmetic overflow exception at seemingly random times.

# Resolution
Instead of using the `new IntPtr(long)` constructor, instead cast to `void*` before `IntPtr`.  This will properly coerce the long value to the value IntPtr expects.

## Known Workarounds
Running the process on the 64-bit platform should eliminate the possibility of the Arithmetic overflow exception.


This pull request should resolve issue #44.

