### PR TITLE
Fix typo in StreamHelper

### DIFF
--- a/Ghostscript.NET/Helpers/StreamHelper.cs
+++ b/Ghostscript.NET/Helpers/StreamHelper.cs
@@ -168,7 +168,7 @@ namespace Ghostscript.NET
 
             do
             {
-                n = output.Read(buffer, 0, buffer.Length);
+                n = input.Read(buffer, 0, buffer.Length);
                 output.Write(buffer, 0, n);
             } while (n != 0);
         }


### PR DESCRIPTION
In StreamHelper, we're reading from output then writing to output, instead of reading from input and writing to output.