### PR TITLE
Fixing GhostScript.NET to work with gs2.27 and above.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,6 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+# Remove extra .vs files.
+/.vs

--- a/Ghostscript.NET/Viewer/FormatHandlers/GhostscriptViewerPdfFormatHandler.cs
+++ b/Ghostscript.NET/Viewer/FormatHandlers/GhostscriptViewerPdfFormatHandler.cs
@@ -82,10 +82,6 @@ namespace Ghostscript.NET.Viewer
                     /DSCPageCount 0 def
                 ");
 
-            // open PDF support dictionaries
-            this.Execute(@"
-                    GS_PDF_ProcSet begin
-                    pdfdict begin");
         }
 
         #endregion
@@ -97,7 +93,7 @@ namespace Ghostscript.NET.Viewer
             filePath = StringHelper.ToUtf8String(filePath);
 
             // open PDF file
-            int res = this.Execute(string.Format("({0}) (r) file runpdfbegin", filePath.Replace("\\", "/")));
+            int res = this.Execute(string.Format("({0}) (r) file runpdfbegin pdfpagecount", filePath.Replace("\\", "/")));
 
             if(res == ierrors.e_ioerror)
             {

--- a/Ghostscript.NET/Viewer/GhostscriptViewer.cs
+++ b/Ghostscript.NET/Viewer/GhostscriptViewer.cs
@@ -384,7 +384,7 @@ namespace Ghostscript.NET.Viewer
                         (int)DISPLAY_FORMAT_FIRSTROW.DISPLAY_BOTTOMFIRST).ToString());
 
 
-
+            args.Add("-dNOSAFER");
             args.Add("-dDOINTERPOLATE");
             args.Add("-dGridFitTT=0");
 


### PR DESCRIPTION
- Adding .vs to .gitignore so local Visual Studio settings are not saved to the repository.
- This will still work on gs2.26 and under as well.
